### PR TITLE
修复 Tacview 类中 server_socket 资源未正确释放的 Bug

### DIFF
--- a/runner/tacview.py
+++ b/runner/tacview.py
@@ -1,47 +1,56 @@
 import socket
 import time
+
 class Tacview(object):
     def __init__(self):
         # Prompt user to input IP address and port number
         host = input("Please enter the server IP address: ")
         port = int(input("Please enter the port number: "))
 
-        # Create a socket
-        server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Create a socket and store it as an instance variable
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-        server_socket.bind((host, port))
+        # Allow reusing the address/port
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        self.server_socket.bind((host, port))
 
         # Start listening
-        server_socket.listen(5)
+        self.server_socket.listen(5)
         print(f"Server listening on {host}:{port}")
         print(f"Please open Tacview Advanced, click Record -> Real-time Telemetry, and input the IP address and port")
 
         # Wait for client connection
-        client_socket, address = server_socket.accept()
-        print(f"Accepted connection from {address}")
-
-        self.client_socket = client_socket
-        self.address = address
+        self.client_socket, self.address = self.server_socket.accept()
+        print(f"Accepted connection from {self.address}")
 
         # Construct handshake data
         handshake_data = "XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nHostUsername\n\x00"
         # Send handshake data
-        client_socket.send(handshake_data.encode())
-
+        self.client_socket.send(handshake_data.encode())
 
         # Receive data from the client
-        data = client_socket.recv(1024)
-        print(f"Received data from {address}: {data.decode()}")
+        data = self.client_socket.recv(1024)
+        print(f"Received data from {self.address}: {data.decode()}")
         print("Connection established")
 
         # Send header data to the client
-
         data_to_send = ("FileType=text/acmi/tacview\nFileVersion=2.1\n"
                         "0,ReferenceTime=2020-04-01T00:00:00Z\n#0.00\n"
                         )
-        client_socket.send(data_to_send.encode())
+        self.client_socket.send(data_to_send.encode())
 
     def send_data_to_client(self, data):
-
         self.client_socket.send(data.encode())
 
+    def __del__(self):
+        """Destructor: Ensure sockets are closed when the object is deleted."""
+        try:
+            # Close client socket if it exists
+            if hasattr(self, 'client_socket') and self.client_socket:
+                self.client_socket.close()    
+            # Close server socket if it exists
+            if hasattr(self, 'server_socket') and self.server_socket:
+                self.server_socket.close()
+        except Exception as e:
+            print(f"Error during cleanup: {e}")


### PR DESCRIPTION
## Bug 原因：

在原始代码中，server_socket 被定义为局部变量，并未存储为 Tacview 类的实例属性（即没有使用 self.server_socket）。这样，在对象销毁时，无法通过 __del__ 方法正确访问和关闭 server_socket，导致程序在重新启动时可能会遇到 Address already in use 的错误，表示套接字地址没有被释放。

## 修复方案：

将 server_socket 和 client_socket 保存为实例属性（self.server_socket 和 self.client_socket），确保它们在整个对象生命周期内可用。
在 __del__ 析构函数中，检查这两个属性是否存在，如果存在则执行关闭操作，确保在对象销毁时正确释放资源，避免套接字地址被占用。