### PR TITLE
修复BaseEnv的render方式中if else的逻辑错误

### DIFF
--- a/envs/JSBSim/envs/env_base.py
+++ b/envs/JSBSim/envs/env_base.py
@@ -221,7 +221,7 @@ class BaseEnv(gymnasium.Env):
                     log_msg = sim.log()
                     if log_msg is not None:
                         f.write(log_msg + "\n")
-        if mode == "real_time":
+        elif mode == "real_time":
             timestamp = self.current_step * self.time_interval
             data = [f"#{timestamp:.2f}\n"]
             for sim in self._jsbsims.values():
@@ -237,8 +237,6 @@ class BaseEnv(gymnasium.Env):
             data_str = "".join(data)
             # send data to tacview
             tacview.send_data_to_client(data_str)
-                
-
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
之前在添加实时渲染时不小心写的小bug：以前默认的else是raise NotImplementatedError, 加了realtime模式后还用两个if会一直走第二个if else，如果此时model=“txt”就会一直触发NotImplementatedError
