### PR TITLE
1、实时渲染：导弹渲染、完善实时渲染异常退出机制、修改仿真终止的日志级别

### DIFF
--- a/envs/JSBSim/termination_conditions/termination_condition_base.py
+++ b/envs/JSBSim/termination_conditions/termination_condition_base.py
@@ -27,4 +27,4 @@ class BaseTerminationCondition(ABC):
         raise NotImplementedError
 
     def log(self, msg):
-        logging.critical(msg)
+        logging.debug(msg)

--- a/runner/jsbsim_runner.py
+++ b/runner/jsbsim_runner.py
@@ -143,6 +143,9 @@ class JSBSimRunner(Runner):
         eval_rnn_states = np.zeros((self.n_eval_rollout_threads, *self.buffer.rnn_states_actor.shape[2:]), dtype=np.float32)
 
         self.timestamp = 0 # use for tacview real time render 
+        if self.render_mode == "real_time" and self.tacview: #reconnect tacview to clear the telemetry
+            print("reconnect tacview.....")
+            self.tacview.reconnect()
         
         while total_episodes < self.eval_episodes:
 
@@ -156,21 +159,24 @@ class JSBSimRunner(Runner):
             # Obser reward and next obs
             eval_obs, eval_rewards, eval_dones, eval_infos = self.eval_envs.step(eval_actions)
 
-             # real render with tacview
+            # real render with tacview
             if self.render_mode == "real_time" and self.tacview:
                 render_data = [f"#{self.timestamp:.2f}\n"]
                 for sim in self.eval_envs.envs[0]._jsbsims.values():
                     log_msg = sim.log()
                     if log_msg is not None:
                         render_data.append(log_msg + "\n")
-
+                for sim in self.eval_envs.envs[0]._tempsims.values():
+                    log_msg = sim.log()
+                    if log_msg is not None:
+                        render_data.append(log_msg + "\n")
                 render_data_str = "".join(render_data)
                 try:
                     self.tacview.send_data_to_client(render_data_str)
                 except Exception as e:
                     logging.error(f"Tacview rendering error: {e}")
-                    
             self.timestamp += 0.2   # step 0.2s
+            
             eval_cumulative_rewards += eval_rewards
             eval_dones_env = np.all(eval_dones.squeeze(axis=-1), axis=-1)
             total_episodes += np.sum(eval_dones_env)

--- a/runner/selfplay_jsbsim_runner.py
+++ b/runner/selfplay_jsbsim_runner.py
@@ -139,6 +139,9 @@ class SelfplayJSBSimRunner(JSBSimRunner):
         eval_cur_opponent_idx = 0
         # use for tacview's timestamp
         self.timestamp = 0
+        if self.render_mode == "real_time" and self.tacview: #reconnect tacview to clear the telemetry
+            print("reconnect tacview.....")
+            self.tacview.reconnect()
         while total_episodes < self.eval_episodes:
 
             # [Selfplay] Load opponent policy
@@ -205,10 +208,12 @@ class SelfplayJSBSimRunner(JSBSimRunner):
                 render_data = [f"#{self.timestamp:.2f}\n"]
                 for sim in self.eval_envs.envs[0]._jsbsims.values():
                     log_msg = sim.log()
-                    
                     if log_msg is not None:
                         render_data.append(log_msg + "\n")
-                        
+                for sim in self.eval_envs.envs[0]._tempsims.values():
+                    log_msg = sim.log()
+                    if log_msg is not None:
+                        render_data.append(log_msg + "\n")
                 render_data_str = "".join(render_data)
                 self.tacview.send_data_to_client(render_data_str)
             self.timestamp += 0.2

--- a/runner/tacview.py
+++ b/runner/tacview.py
@@ -1,15 +1,39 @@
 import socket
-import time
+import atexit
+import signal
+import sys
 
 class Tacview(object):
     def __init__(self):
-
+        atexit.register(self.cleanup)  # 注册退出清理
+        signal.signal(signal.SIGTSTP, self.handle_sigtstp)  # 捕获 Ctrl+Z
+        signal.signal(signal.SIGINT, self.handle_sigint)  # 捕获 Ctrl+C
+        # 确保程序在：正常退出、Ctrl+C 终止、Ctrl+Z 挂起、异常退出都能正确释放资源
         # Automatically get the local machine's IP address
-        self.host = socket.gethostbyname(socket.gethostname())
+        self.host = self.get_ip_address() # to show the real ip
         # Default starting port
         self.port = 12345
         self.setup_server()
-        
+    
+    def handle_sigtstp(self, signum, frame):
+        """ 处理 Ctrl+Z 信号 """
+        print("\n捕获到 Ctrl+Z，正在清理资源...")
+        self.cleanup()
+        sys.exit(0)  # 退出程序
+
+    def handle_sigint(self, signum, frame):
+        """ 处理 Ctrl+C 信号 """
+        print("\n捕获到 Ctrl+C，正在清理资源...")
+        self.cleanup()
+        sys.exit(0)  # 退出程序
+
+    def get_ip_address(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('8.8.8.8', 80))  # Google DNS, 只是为了获得正确的IP地址
+        ip_address = s.getsockname()[0]
+        s.close()
+        return ip_address
+    
     def setup_server(self):
         try:
             self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/runner/tacview.py
+++ b/runner/tacview.py
@@ -3,58 +3,77 @@ import time
 
 class Tacview(object):
     def __init__(self):
+
         # Automatically get the local machine's IP address
-        host = socket.gethostbyname(socket.gethostname())
+        self.host = socket.gethostbyname(socket.gethostname())
         # Default starting port
-        port = 12345
-
-        # Create a socket and store it as an instance variable
-        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        # Allow reusing the address/port
-        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        self.server_socket.bind((host, port))
-
-        # Start listening
-        self.server_socket.listen(5)
-        print(f"Server listening on {host}:{port}")
-        # Output more prominent message
-        print("\n" + "*" * 50)
-        print("! IMPORTANT: Please open Tacview Advanced, click Record -> Real-time Telemetry, and input the IP address and port !")
-        print("*" * 50 + "\n")
-
-        # Wait for client connection
-        self.client_socket, self.address = self.server_socket.accept()
-        print(f"Accepted connection from {self.address}")
-
-        # Construct handshake data
-        handshake_data = "XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nHostUsername\n\x00"
-        # Send handshake data
-        self.client_socket.send(handshake_data.encode())
-
-        # Receive data from the client
-        data = self.client_socket.recv(1024)
-        print(f"Received data from {self.address}: {data.decode()}")
-        print("Connection established")
-
-        # Send header data to the client
-        data_to_send = ("FileType=text/acmi/tacview\nFileVersion=2.1\n"
-                        "0,ReferenceTime=2020-04-01T00:00:00Z\n#0.00\n"
-                        )
-        self.client_socket.send(data_to_send.encode())
+        self.port = 12345
+        self.setup_server()
+        
+    def setup_server(self):
+        try:
+            self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.server_socket.bind((self.host, self.port))
+            self.server_socket.listen(5)
+            print(f"Server listening on {self.host}:{self.port}")
+            # Output more prominent message
+            print("\n" + "*" * 50)
+            print("! IMPORTANT: Please open Tacview Advanced, click Record -> Real-time Telemetry, and input the IP address and port !")
+            print("*" * 50 + "\n")
+            self.connect()
+        except Exception as e:
+            print(f"Setup error: {e}")
+            self.cleanup()
+            raise
 
     def send_data_to_client(self, data):
-        self.client_socket.send(data.encode())
-
-    def __del__(self):
-        """Destructor: Ensure sockets are closed when the object is deleted."""
         try:
-            # Close client socket if it exists
+            self.client_socket.send(data.encode())
+        except Exception as e:
+            print(f"Send error: {e}")
+            self.reconnect()
+            
+    def connect(self):
+        try:
+            print("Waiting for connection...")
+            self.client_socket, self.address = self.server_socket.accept()
+            print(f"Accepted connection from {self.address}")
+            
+            # 发送握手数据
+            handshake_data = "XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nHostUsername\n\x00"
+            self.client_socket.send(handshake_data.encode())
+            
+            # 接收客户端响应
+            data = self.client_socket.recv(1024)
+            print(f"Received data from {self.address}: {data.decode()}")
+            
+            # 发送头部数据
+            header_data = ("FileType=text/acmi/tacview\nFileVersion=2.1\n"
+                          "0,ReferenceTime=2020-04-01T00:00:00Z\n#0.00\n")
+            self.client_socket.send(header_data.encode())
+            print("Connection established")
+            
+        except Exception as e:
+            print(f"Connection error: {e}")
+            self.cleanup()
+            raise
+
+    def reconnect(self):
+        print("Attempting to reconnect...")
+        self.cleanup()
+        self.setup_server()
+
+    def cleanup(self):
+        try:
             if hasattr(self, 'client_socket') and self.client_socket:
-                self.client_socket.close()    
-            # Close server socket if it exists
+                self.client_socket.close()
+                self.client_socket = None
             if hasattr(self, 'server_socket') and self.server_socket:
                 self.server_socket.close()
+                self.server_socket = None
         except Exception as e:
-            print(f"Error during cleanup: {e}")
+            print(f"Cleanup error: {e}")
+
+    def __del__(self):
+        self.cleanup()


### PR DESCRIPTION
改动1：tacview实时渲染改为重连渲染，加入导弹的渲染
目前实时渲染的实现中，给tacview软件发数据的时候，没有清空之前的数据，会导致拖动tacview进度条时，飞机会有瞬移的现象。在咨询了tacview官方的建议：重新连接。可以解决问题
tacview的官方意见：
![1f6a6cfc3c83bd276926086b7b75d8c](https://github.com/user-attachments/assets/ab19b06a-c8a3-4d38-a49c-b0148901143d)

改动2：完善tacview异常退出机制，当代码与tacview建立连接前如果使用ctrl z 或者ctrl c挂起或终止程序时，释放端口，解决Address already in use的问题

改动3：[pr58将BaseTerminationCondition类的log级别升级为critical](https://github.com/liuqh16/LAG/pull/58 )这个pr当时改的有问题，只考虑了调试的开发效率，贸然将log级别升级为critical，如果但凡主函数设定了日志级别为INFO（方便打印训练信息），logging库的日志级别优先顺序为DEBUG < INFO < WARNING < ERROR < CRITICAL。那么只要是日志级别高于INFO的都会输出，导致训练时大量输出日志影响效率。

```
logging.basicConfig(level=logging.INFO, format="%(message)s")
```
综合考虑，在不大量改动本项目所使用日志库的情况下，只能将日志级别改回debug
```
class BaseTerminationCondition(ABC):
    """
    Base TerminationCondition class
    Condition-specific get_termination method is implemented in subclasses
    """

    def log(self, msg):
        logging.debug(msg)
```