### PR TITLE
Enhance rendering: Add trajectory saving for historical evaluation

### DIFF
--- a/runner/selfplay_jsbsim_runner.py
+++ b/runner/selfplay_jsbsim_runner.py
@@ -4,6 +4,7 @@ import numpy as np
 from typing import List
 from .base_runner import Runner, ReplayBuffer
 from .jsbsim_runner import JSBSimRunner
+import os
 
 
 def _t2n(x):
@@ -11,7 +12,6 @@ def _t2n(x):
 
 
 class SelfplayJSBSimRunner(JSBSimRunner):
-
     def load(self):
         self.use_selfplay = self.all_args.use_selfplay 
         assert self.use_selfplay == True, "Only selfplay can use SelfplayRunner"
@@ -137,11 +137,18 @@ class SelfplayJSBSimRunner(JSBSimRunner):
         logging.info(f" Choose opponents {eval_choose_opponents} for evaluation")
 
         eval_cur_opponent_idx = 0
-        # use for tacview's timestamp
-        self.timestamp = 0
+        
+        self.timestamp = 0 # use for tacview's timestamp
+        interval_timestamp = self.envs.envs[0].agent_interaction_steps  / self.envs.envs[0].sim_freq
         if self.render_mode == "real_time" and self.tacview: #reconnect tacview to clear the telemetry
             print("reconnect tacview.....")
             self.tacview.reconnect()
+        # Create a directory to save .acmi files
+        elif self.render_mode == "histroy_acmi":
+            save_dir = os.path.join(self.run_dir, 'acmi_files')
+            os.makedirs(save_dir, exist_ok=True)
+            acmi_filename = f"{save_dir}/eval_episode_{self.current_episode}.acmi"
+        
         while total_episodes < self.eval_episodes:
 
             # [Selfplay] Load opponent policy
@@ -181,6 +188,25 @@ class SelfplayJSBSimRunner(JSBSimRunner):
             dones_env = np.all(dones.squeeze(axis=-1), axis=-1)
             total_episodes += np.sum(dones_env)
 
+            # render data
+            render_data = [f"#{self.timestamp:.2f}\n"]
+            for sim in self.eval_envs.envs[0]._jsbsims.values():
+                log_msg = sim.log()
+                if log_msg is not None:
+                    render_data.append(log_msg + "\n")
+            for sim in self.eval_envs.envs[0]._tempsims.values():
+                log_msg = sim.log()
+                if log_msg is not None:
+                    render_data.append(log_msg + "\n")
+            render_data_str = "".join(render_data)
+            
+            # Rendering for visualization.
+            if self.render_mode == "real_time" and self.tacview:
+                self.tacview.send_data_to_client(render_data_str)
+            if self.render_mode == "histroy_acmi" and self._should_save_acmi():
+                self._save_acmi(acmi_filename, self.add_acmi_header(render_data_str))
+            self.timestamp += interval_timestamp
+                
             # [Selfplay] Reset obs, masks, rnn_states
             opponent_obs = obs[:, self.num_agents // 2:, ...]
             obs = obs[:, :self.num_agents // 2, ...]
@@ -203,20 +229,8 @@ class SelfplayJSBSimRunner(JSBSimRunner):
             episode_rewards.append(cumulative_rewards[dones_env == True])
             cumulative_rewards[dones_env == True] = 0
             
-            # Tacview real time render
-            if self.render_mode == "real_time":
-                render_data = [f"#{self.timestamp:.2f}\n"]
-                for sim in self.eval_envs.envs[0]._jsbsims.values():
-                    log_msg = sim.log()
-                    if log_msg is not None:
-                        render_data.append(log_msg + "\n")
-                for sim in self.eval_envs.envs[0]._tempsims.values():
-                    log_msg = sim.log()
-                    if log_msg is not None:
-                        render_data.append(log_msg + "\n")
-                render_data_str = "".join(render_data)
-                self.tacview.send_data_to_client(render_data_str)
-            self.timestamp += 0.2
+
+            
 
         # Compute average episode rewards
         episode_rewards = np.concatenate(episode_rewards) # shape (self.eval_episodes, self.num_agents, 1)

--- a/scripts/train/train_jsbsim.py
+++ b/scripts/train/train_jsbsim.py
@@ -75,8 +75,12 @@ def parse_args(args, parser):
     group = parser.add_argument_group("JSBSim Env parameters")
     group.add_argument('--scenario-name', type=str, default='singlecombat_simple',
                        help="Which scenario to run on")
-    group.add_argument('--render-mode', type=str, default='txt',
-                       help="txt or real_time")
+    group.add_argument('--render-mode', type=str, default='histroy_acmi',
+                   help="Rendering mode for visualization. "
+                        "'histroy_acmi' saves trajectory data to an ACMI file at every evaluation interval, "
+                        "allowing for post-analysis of historical evaluations. "
+                        "'real_time' maintains a live connection with Tacview for real-time visualization, "
+                        "but requires Tacview Advanced support.")
     all_args = parser.parse_known_args(args)[0]
     return all_args
 

--- a/scripts/train_heading.sh
+++ b/scripts/train_heading.sh
@@ -7,8 +7,9 @@ seed=5
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=0 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda \
     --log-interval 1 --save-interval 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \

--- a/scripts/train_selfplay.sh
+++ b/scripts/train_selfplay.sh
@@ -7,10 +7,10 @@ seed=1
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=1 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda --log-interval 1 --save-interval 1 \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda --log-interval 1 --save-interval 1 \
     --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 \
-    --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \
     --hidden-size "128 128" --act-hidden-size "128 128" --recurrent-hidden-size 128 --recurrent-hidden-layers 1 --data-chunk-length 8 \

--- a/scripts/train_share_selfplay.sh
+++ b/scripts/train_share_selfplay.sh
@@ -8,11 +8,10 @@ seed=0
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=0 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda --log-interval 1 --save-interval 1 \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda --log-interval 1 --save-interval 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \
     --hidden-size "128 128" --act-hidden-size "128 128" --recurrent-hidden-size 128 --recurrent-hidden-layers 1 --data-chunk-length 8 \
-    --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 \
-    --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
-    --user-name "jyh" --use-wandb --wandb-name "thu_jsbsim" \
+    --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 


### PR DESCRIPTION
1、添加记录历史可视化acmi轨迹
--render-mode添加histroy_acmi选项，默认根据--eval-interval的为间隔记录历史轨迹，相比与real_time来说，既不需要Tacview Advanced版，也相比于一直盯着tacview来观察更加灵活，在训练完成后，可以查看任意epoch时评估的可视化轨迹，
```
group.add_argument('--render-mode', type=str, default='histroy_acmi',
                   help="Rendering mode for visualization. "
                        "'histroy_acmi' saves trajectory data to an ACMI file at every evaluation interval, "
                        "allowing for post-analysis of historical evaluations. "
                        "'real_time' maintains a live connection with Tacview for real-time visualization, "
                        "but requires Tacview Advanced support.")
```

2、取消代码中关于render时间间隔的硬编码，采用根据yaml文件中设定的sim_freq和agent_interaction_steps来计算render时的时间间隔：agent_interaction_steps / sim_freq
```
interval_timestamp = self.envs.envs[0].agent_interaction_steps  / self.envs.envs[0].sim_freq
```

Pre:
```
self.timestamp += 0.2  # step 0.2s
```
Now:
```
self.timestamp += interval_timestamp  # step 0.2s
```