### PR TITLE
Enhance rendering: Add trajectory saving for historical evaluation(Code Refactoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,33 +75,25 @@ python render*.py
 ```
 This will generate a `*.acmi` file. We can use [**TacView**](https://www.tacview.net/), a universal flight analysis tool, to open the file and watch the render videos.
 
-### Real-time Telemetry Rendering during Training
+## Rendering Modes for Visualization In Training
 
-We have added support for real-time telemetry rendering using **Tacview Advanced**. This feature allows you to visualize the training process dynamically, providing a clearer understanding of the simulation data and agent behaviors.
+We now support two rendering modes for visualizing agent training:
 
-#### How to Enable Real-time Rendering
+### 1. `history_acmi`
+- **Description**: Saves trajectory data to an ACMI file at every evaluation interval. This allows you to perform post-analysis of the historical evaluations.
+- **Usage**: 
+```bash
+bash train_selfplay.sh --render-mode history_acmi --eval-interval 10
+```
+This will save the trajectory data to an ACMI file every 10 episodes.
 
-**Note:** This feature is exclusively available with **Tacview Advanced**, as only the Advanced version supports real-time telemetry.
-
-1. **Set `real_time`、`--use-eval` and `--eval-interval` Parameters**:
-   To enable real-time rendering, include the parameter `--render-mode real_time` in the training script command. 
-   Real-time rendering occurs during the evaluation process. Enable evaluation mode by setting the parameter `--use-eval`. Use `--eval-interval` to control how often evaluation and visualization are performed. For example:
-   ```bash
-   bash train_selfplay.sh --render-mode real_time --use-eval --eval-interval 32
-   ```
-   **Caution:** Real-time visualization may impact performance. Choose an appropriate `--eval-interval` value (e.g., `1` for every episode, `10` for every 10 episodes) based on your system capabilities.
-
-2. **Configure Tacview**:
-   - Ensure you have **Tacview Advanced** installed.
-   - In Tacview, go to **Record -> Real-time Telemetry**, and input the IP address and port displayed in the training console output (e.g., `192.168.1.120:12345`).
-
-#### Notes
-- **Tacview Requirement**: This feature requires Tacview Advanced to be installed and properly configured.
-- **Optional Use**: If `--render-mode` is not set to `real_time`, the training process will proceed without real-time rendering.
-- **Evaluation-based Rendering**: Real-time rendering is tied to the evaluation process and controlled by `--eval-interval`.
-- **Non-blocking**: Real-time rendering will not interfere with the training process. It is designed to work seamlessly alongside the existing pipeline.
-
-This functionality enhances training visualization, making it easier to debug and analyze the agent's performance during the simulation.
+### 2. `real_time`
+- **Description**: Maintains a live connection with Tacview Advanced for real-time visualization of the simulation. This mode provides dynamic tracking of agent behavior during training..
+- **Usage**: 
+```bash
+bash train_selfplay.sh --render-mode real_time --use-eval --eval-interval 10
+```
+Real-time telemetry will be sent to Tacview at the specified --eval-interval. Ensure Tacview Advanced is installed and configured to visualize the data.
 
 ## Citing
 If you find this repo useful, pleased use the following citation:

--- a/runner/base_runner.py
+++ b/runner/base_runner.py
@@ -18,6 +18,7 @@ class Runner(object):
         self.envs = config['envs']
         self.eval_envs = config['eval_envs']
         self.device = config['device']
+        self.current_episode = 0
         self.render_mode = config['render_mode']
         
         # Tacview render obj
@@ -25,7 +26,7 @@ class Runner(object):
         if self.render_mode == "real_time":
             from runner.tacview import Tacview
             self.tacview = Tacview()
-
+        
         # parameters
         self.env_name = self.all_args.env_name
         self.algorithm_name = self.all_args.algorithm_name
@@ -55,6 +56,13 @@ class Runner(object):
 
         self.load()
 
+    def _should_save_acmi(self):
+        """ 判断是否应该保存 ACMI 文件 """
+        return (
+            self.current_episode % self.eval_interval == 0
+            and self.use_eval
+        )
+        
     def load(self):
         # algorithm
         if self.algorithm_name == "ppo":

--- a/runner/jsbsim_runner.py
+++ b/runner/jsbsim_runner.py
@@ -1,3 +1,4 @@
+import os
 import time
 import torch
 import logging
@@ -41,7 +42,9 @@ class JSBSimRunner(Runner):
         episodes = self.num_env_steps // self.buffer_size // self.n_rollout_threads
 
         for episode in range(episodes):
-
+            
+            self.current_episode = episode
+            
             heading_turns_list = []
 
             for step in range(self.buffer_size):
@@ -91,7 +94,7 @@ class JSBSimRunner(Runner):
 
             # eval
             if episode % self.eval_interval == 0 and episode != 0 and self.use_eval:
-                    self.eval(self.total_num_steps)
+                self.eval(self.total_num_steps)
 
             # save model
             if (episode % self.save_interval == 0) or (episode == episodes - 1):
@@ -143,9 +146,14 @@ class JSBSimRunner(Runner):
         eval_rnn_states = np.zeros((self.n_eval_rollout_threads, *self.buffer.rnn_states_actor.shape[2:]), dtype=np.float32)
 
         self.timestamp = 0 # use for tacview real time render 
+        interval_timestamp = self.envs.envs[0].agent_interaction_steps  / self.envs.envs[0].sim_freq      
         if self.render_mode == "real_time" and self.tacview: #reconnect tacview to clear the telemetry
             print("reconnect tacview.....")
-            self.tacview.reconnect()
+            self.tacview.reconnect()         
+        #  Create a directory to save .acmi files only use for render mode is histroy_acmi 
+        save_dir = os.path.join(self.run_dir, 'acmi_files')
+        os.makedirs(save_dir, exist_ok=True)
+        acmi_filename = f"{save_dir}/eval_episode_{self.current_episode}.acmi"
         
         while total_episodes < self.eval_episodes:
 
@@ -158,24 +166,11 @@ class JSBSimRunner(Runner):
 
             # Obser reward and next obs
             eval_obs, eval_rewards, eval_dones, eval_infos = self.eval_envs.step(eval_actions)
-
-            # real render with tacview
-            if self.render_mode == "real_time" and self.tacview:
-                render_data = [f"#{self.timestamp:.2f}\n"]
-                for sim in self.eval_envs.envs[0]._jsbsims.values():
-                    log_msg = sim.log()
-                    if log_msg is not None:
-                        render_data.append(log_msg + "\n")
-                for sim in self.eval_envs.envs[0]._tempsims.values():
-                    log_msg = sim.log()
-                    if log_msg is not None:
-                        render_data.append(log_msg + "\n")
-                render_data_str = "".join(render_data)
-                try:
-                    self.tacview.send_data_to_client(render_data_str)
-                except Exception as e:
-                    logging.error(f"Tacview rendering error: {e}")
-            self.timestamp += 0.2   # step 0.2s
+            
+            # render with tacview
+            self.eval_envs.envs[0].render_with_tacview(self.render_mode, self.tacview, acmi_filename, self.eval_envs.envs[0], self.timestamp, self._should_save_acmi())
+            
+            self.timestamp += interval_timestamp   # step 0.2s
             
             eval_cumulative_rewards += eval_rewards
             eval_dones_env = np.all(eval_dones.squeeze(axis=-1), axis=-1)

--- a/runner/share_jsbsim_runner.py
+++ b/runner/share_jsbsim_runner.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import time
 from typing import List
@@ -73,6 +74,8 @@ class ShareJSBSimRunner(Runner):
 
         for episode in range(episodes):
 
+            self.current_episode = episode
+            
             for step in range(self.buffer_size):
                 # Sample actions
                 values, actions, action_log_probs, rnn_states_actor, rnn_states_critic = self.collect(step)
@@ -218,6 +221,17 @@ class ShareJSBSimRunner(Runner):
             logging.info(f" Choose opponents {eval_choose_opponents} for evaluation")
             # TODO: use eval results to update elo
 
+        # use for tacview's timestamp
+        self.timestamp = 0
+        interval_timestamp = self.envs.envs[0].agent_interaction_steps  / self.envs.envs[0].sim_freq
+        if self.render_mode == "real_time" and self.tacview: #reconnect tacview to clear the telemetry
+            print("reconnect tacview.....")
+            self.tacview.reconnect()         
+        #  Create a directory to save .acmi files only use for render mode is histroy_acmi 
+        save_dir = os.path.join(self.run_dir, 'acmi_files')
+        os.makedirs(save_dir, exist_ok=True)
+        acmi_filename = f"{save_dir}/eval_episode_{self.current_episode}.acmi"
+        
         while total_episodes < self.eval_episodes:
 
             # [Selfplay] Load opponent policy
@@ -257,6 +271,10 @@ class ShareJSBSimRunner(Runner):
             # Obser reward and next obs
             eval_obs, eval_share_obs, eval_rewards, eval_dones, eval_infos = self.eval_envs.step(eval_actions)
 
+            # render with tacview
+            self.eval_envs.envs[0].render_with_tacview(self.render_mode, self.tacview, acmi_filename, self.eval_envs.envs[0], self.timestamp, self._should_save_acmi())
+            self.timestamp += interval_timestamp   # step 0.2s
+            
             # [Selfplay] get ego reward
             if self.use_selfplay:
                 eval_rewards = eval_rewards[:, :self.num_agents // 2, ...]

--- a/scripts/train/train_jsbsim.py
+++ b/scripts/train/train_jsbsim.py
@@ -75,8 +75,12 @@ def parse_args(args, parser):
     group = parser.add_argument_group("JSBSim Env parameters")
     group.add_argument('--scenario-name', type=str, default='singlecombat_simple',
                        help="Which scenario to run on")
-    group.add_argument('--render-mode', type=str, default='txt',
-                       help="txt or real_time")
+    group.add_argument('--render-mode', type=str, default='histroy_acmi',
+                   help="Rendering mode for visualization. "
+                        "'histroy_acmi' saves trajectory data to an ACMI file at every evaluation interval, "
+                        "allowing for post-analysis of historical evaluations. "
+                        "'real_time' maintains a live connection with Tacview for real-time visualization, "
+                        "but requires Tacview Advanced support.")
     all_args = parser.parse_known_args(args)[0]
     return all_args
 

--- a/scripts/train_heading.sh
+++ b/scripts/train_heading.sh
@@ -7,8 +7,9 @@ seed=5
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=0 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda \
     --log-interval 1 --save-interval 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \

--- a/scripts/train_selfplay.sh
+++ b/scripts/train_selfplay.sh
@@ -7,11 +7,10 @@ seed=1
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=1 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda --log-interval 1 --save-interval 1 \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda --log-interval 1 --save-interval 1 \
     --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 \
-    --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \
-    --hidden-size "128 128" --act-hidden-size "128 128" --recurrent-hidden-size 128 --recurrent-hidden-layers 1 --data-chunk-length 8 \
-    --user-name "jyh" --use-wandb --wandb-name "thu_jsbsim" \
+    --hidden-size "128 128" --act-hidden-size "128 128" --recurrent-hidden-size 128 --recurrent-hidden-layers 1 --data-chunk-length 8

--- a/scripts/train_selfplay_shoot.sh
+++ b/scripts/train_selfplay_shoot.sh
@@ -8,10 +8,10 @@ seed=1
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=1 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda --log-interval 1 --save-interval 1 \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda --log-interval 1 --save-interval 1 \
     --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 \
-    --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \
     --hidden-size "128 128" --act-hidden-size "128 128" --recurrent-hidden-size 128 --recurrent-hidden-layers 1 --data-chunk-length 8 \

--- a/scripts/train_share_selfplay.sh
+++ b/scripts/train_share_selfplay.sh
@@ -8,11 +8,10 @@ seed=0
 
 echo "env is ${env}, scenario is ${scenario}, algo is ${algo}, exp is ${exp}, seed is ${seed}"
 CUDA_VISIBLE_DEVICES=0 python train/train_jsbsim.py \
+    --render-mode histroy_acmi --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
     --env-name ${env} --algorithm-name ${algo} --scenario-name ${scenario} --experiment-name ${exp} \
-    --seed ${seed} --n-training-threads 1 --n-rollout-threads 32 --cuda --log-interval 1 --save-interval 1 \
+    --seed ${seed} --n-training-threads 1 --n-rollout-threads 1 --cuda --log-interval 1 --save-interval 1 \
     --num-mini-batch 5 --buffer-size 3000 --num-env-steps 1e8 \
     --lr 3e-4 --gamma 0.99 --ppo-epoch 4 --clip-params 0.2 --max-grad-norm 2 --entropy-coef 1e-3 \
     --hidden-size "128 128" --act-hidden-size "128 128" --recurrent-hidden-size 128 --recurrent-hidden-layers 1 --data-chunk-length 8 \
-    --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 \
-    --use-eval --n-eval-rollout-threads 1 --eval-interval 1 --eval-episodes 1 \
-    --user-name "jyh" --use-wandb --wandb-name "thu_jsbsim" \
+    --use-selfplay --selfplay-algorithm "fsp" --n-choose-opponents 1 


### PR DESCRIPTION
已将训练评估过程的渲染逻辑移动到env.base.py中
1、添加记录历史可视化acmi轨迹
--render-mode添加histroy_acmi选项，默认根据--eval-interval的为间隔记录历史轨迹，相比与real_time来说，既不需要Tacview Advanced版，也相比于一直盯着tacview来观察更加灵活，在训练完成后，可以查看任意epoch时评估的可视化轨迹，

```
group.add_argument('--render-mode', type=str, default='histroy_acmi',
                   help="Rendering mode for visualization. "
                        "'histroy_acmi' saves trajectory data to an ACMI file at every evaluation interval, "
                        "allowing for post-analysis of historical evaluations. "
                        "'real_time' maintains a live connection with Tacview for real-time visualization, "
                        "but requires Tacview Advanced support.")
```
2、取消代码中关于render时间间隔的硬编码，采用根据yaml文件中设定的sim_freq和agent_interaction_steps来计算render时的时间间隔：agent_interaction_steps / sim_freq
```
interval_timestamp = self.envs.envs[0].agent_interaction_steps  / self.envs.envs[0].sim_freq
```
Pre:
```
self.timestamp += 0.2  # step 0.2s
```
Now:
```
self.timestamp += interval_timestamp  # step 0.2s
```